### PR TITLE
generator-java: handle union types

### DIFF
--- a/spotify-web-api-core/src/main/java/de/sonallux/spotify/core/SpotifyWebApiObjectUtils.java
+++ b/spotify-web-api-core/src/main/java/de/sonallux/spotify/core/SpotifyWebApiObjectUtils.java
@@ -1,0 +1,30 @@
+package de.sonallux.spotify.core;
+
+import de.sonallux.spotify.core.model.SpotifyWebApiObject;
+
+import java.util.List;
+
+public class SpotifyWebApiObjectUtils {
+    private static final List<String> BASE_OBJECT_PROPERTY_NAMES = List.of("id", "type", "href", "uri");
+    public static final List<String> BASE_OBJECT_NAMES = List.of("AlbumObject", "ArtistObject", "EpisodeObject", "PlaylistObject", "ShowObject", "TrackObject", "UserObject");
+    public static final String BASE_OBJECT_NAME = "BaseObject";
+    public static final SpotifyWebApiObject SPOTIFY_BASE_OBJECT = new SpotifyWebApiObject(BASE_OBJECT_NAME)
+        .addProperty(new SpotifyWebApiObject.Property("id", "String", "The [Spotify ID](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids) for the object."))
+        .addProperty(new SpotifyWebApiObject.Property("type", "String", "The object type."))
+        .addProperty(new SpotifyWebApiObject.Property("href", "String", "A link to the Web API endpoint providing full details of the object."))
+        .addProperty(new SpotifyWebApiObject.Property("uri", "String", "The [Spotify URI](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids) for the object."));
+
+    public static boolean isBaseObject(SpotifyWebApiObject object) {
+        return object.getProperties().stream()
+            .filter(p -> BASE_OBJECT_PROPERTY_NAMES.contains(p.getName()))
+            .count() == BASE_OBJECT_PROPERTY_NAMES.size();
+    }
+
+    public static boolean removeBaseProperties(SpotifyWebApiObject object) {
+        if (BASE_OBJECT_NAME.equals(object.getName()) || !isBaseObject(object)) {
+            return false;
+        }
+        object.getProperties().removeIf(p -> BASE_OBJECT_PROPERTY_NAMES.contains(p.getName()));
+        return true;
+    }
+}

--- a/spotify-web-api-generator-java/src/main/java/de/sonallux/spotify/generator/java/JavaGenerator.java
+++ b/spotify-web-api-generator-java/src/main/java/de/sonallux/spotify/generator/java/JavaGenerator.java
@@ -2,6 +2,7 @@ package de.sonallux.spotify.generator.java;
 
 import com.github.mustachejava.MustacheFactory;
 import de.sonallux.spotify.core.EndpointSplitter;
+import de.sonallux.spotify.core.SpotifyWebApiObjectUtils;
 import de.sonallux.spotify.core.model.SpotifyWebApi;
 import de.sonallux.spotify.generator.java.templates.*;
 import de.sonallux.spotify.generator.java.util.JavaPackage;
@@ -24,6 +25,9 @@ public class JavaGenerator {
         } catch (IllegalArgumentException e) {
             throw new GeneratorException("Failed to split endpoints", e);
         }
+
+        var baseObjectTemplate = new BaseObjectTemplate().loadTemplate(this.mustacheFactory);
+        baseObjectTemplate.generate(SpotifyWebApiObjectUtils.SPOTIFY_BASE_OBJECT, outputFolder, javaPackage);
 
         var objectTemplate = new ObjectTemplate().loadTemplate(this.mustacheFactory);
         for (var object : spotifyWebApi.getObjectList()) {

--- a/spotify-web-api-generator-java/src/main/java/de/sonallux/spotify/generator/java/templates/BaseObjectTemplate.java
+++ b/spotify-web-api-generator-java/src/main/java/de/sonallux/spotify/generator/java/templates/BaseObjectTemplate.java
@@ -1,0 +1,27 @@
+package de.sonallux.spotify.generator.java.templates;
+
+import de.sonallux.spotify.core.SpotifyWebApiObjectUtils;
+import de.sonallux.spotify.core.model.SpotifyWebApiObject;
+import de.sonallux.spotify.generator.java.util.JavaUtils;
+
+import java.util.Map;
+
+public class BaseObjectTemplate extends ObjectTemplate {
+    @Override
+    public String templateName() {
+        return "base-object";
+    }
+
+    @Override
+    public String getFileName(SpotifyWebApiObject object) {
+        return JavaUtils.getFileName(SpotifyWebApiObjectUtils.BASE_OBJECT_NAME);
+    }
+
+    @Override
+    public Map<String, Object> buildContext(SpotifyWebApiObject object, Map<String, Object> rootContext) {
+        var context = super.buildContext(object, rootContext);
+        context.put("className", SpotifyWebApiObjectUtils.BASE_OBJECT_NAME);
+
+        return context;
+    }
+}

--- a/spotify-web-api-generator-java/src/main/java/de/sonallux/spotify/generator/java/templates/ObjectTemplate.java
+++ b/spotify-web-api-generator-java/src/main/java/de/sonallux/spotify/generator/java/templates/ObjectTemplate.java
@@ -1,6 +1,7 @@
 package de.sonallux.spotify.generator.java.templates;
 
 import com.google.common.base.Strings;
+import de.sonallux.spotify.core.SpotifyWebApiObjectUtils;
 import de.sonallux.spotify.core.model.SpotifyWebApiObject;
 import de.sonallux.spotify.generator.java.util.JavaPackage;
 import de.sonallux.spotify.generator.java.util.JavaUtils;
@@ -33,6 +34,11 @@ public class ObjectTemplate extends AbstractTemplate<SpotifyWebApiObject> {
 
     @Override
     public Map<String, Object> buildContext(SpotifyWebApiObject object, Map<String, Object> context) {
+        if (SpotifyWebApiObjectUtils.removeBaseProperties(object)) {
+            context.put("extendsBaseObject", true);
+            context.put("superClass", SpotifyWebApiObjectUtils.BASE_OBJECT_NAME);
+        }
+
         context.put("name", object.getName());
         context.put("className", getClassName(object));
         context.put("properties", object.getProperties().stream().map(this::buildPropertyContext).collect(Collectors.toList()));

--- a/spotify-web-api-generator-java/src/main/java/de/sonallux/spotify/generator/java/util/JavaUtils.java
+++ b/spotify-web-api-generator-java/src/main/java/de/sonallux/spotify/generator/java/util/JavaUtils.java
@@ -10,6 +10,7 @@ import java.util.regex.Matcher;
 
 import static com.google.common.base.CaseFormat.LOWER_CAMEL;
 import static com.google.common.base.CaseFormat.LOWER_UNDERSCORE;
+import static de.sonallux.spotify.core.SpotifyWebApiObjectUtils.BASE_OBJECT_NAMES;
 
 public class JavaUtils {
     public static final List<String> RESERVED_WORDS = Arrays.asList(
@@ -64,6 +65,10 @@ public class JavaUtils {
         } else if ((matcher = SpotifyWebApiUtils.CURSOR_PAGING_OBJECT_TYPE_PATTERN.matcher(type)).matches()) {
             return "CursorPaging<" + mapToJavaType(matcher.group(1)) + ">";
         } else if (type.contains(" | ")) {
+            if (Arrays.stream(type.split(" \\| "))
+                .allMatch(BASE_OBJECT_NAMES::contains)) {
+                return "BaseObject";
+            }
             //Can not be mapped easily, so just use Map
             return "java.util.Map<String, Object>";
         } else {

--- a/spotify-web-api-generator-java/src/main/resources/templates/base-object.mustache
+++ b/spotify-web-api-generator-java/src/main/resources/templates/base-object.mustache
@@ -1,0 +1,42 @@
+package {{package}};
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.*;
+
+{{#documentationLink}}
+/**
+ * <a href="{{documentationLink}}">{{name}}</a>
+ */
+{{/documentationLink}}
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Album.class, name = "album"),
+    @JsonSubTypes.Type(value = Artist.class, name = "artist"),
+    @JsonSubTypes.Type(value = Episode.class, name = "episode"),
+    @JsonSubTypes.Type(value = Playlist.class, name = "playlist"),
+    @JsonSubTypes.Type(value = Show.class, name = "show"),
+    @JsonSubTypes.Type(value = Track.class, name = "track"),
+    @JsonSubTypes.Type(value = PrivateUser.class, name = "user"),
+})
+public abstract class {{className}} {
+{{#properties}}
+    {{#hasDescription}}
+    /**
+    {{#description}}
+     * {{.}}
+    {{/description}}
+     */
+    {{/hasDescription}}
+    {{#nonNull}}
+    @NonNull
+    {{/nonNull}}
+    {{#isReservedKeywordProperty}}
+    @lombok.experimental.Accessors(prefix = "_")
+    {{/isReservedKeywordProperty}}
+    public {{type}} {{fieldName}};
+{{/properties}}
+}

--- a/spotify-web-api-generator-java/src/main/resources/templates/object.mustache
+++ b/spotify-web-api-generator-java/src/main/resources/templates/object.mustache
@@ -1,5 +1,8 @@
 package {{package}};
 
+{{#extendsBaseObject}}
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+{{/extendsBaseObject}}
 import lombok.*;
 
 {{#documentationLink}}
@@ -10,6 +13,9 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
+{{#extendsBaseObject}}
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Disable deserialization based on @JsonTypeInfo
+{{/extendsBaseObject}}
 public class {{className}}{{#superClass}} extends {{superClass}}{{/superClass}} {
 {{#properties}}
     {{#hasDescription}}

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/Album.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/Album.java
@@ -1,5 +1,6 @@
 package de.sonallux.spotify.api.models;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.*;
 
 /**
@@ -8,7 +9,8 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
-public class Album {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Disable deserialization based on @JsonTypeInfo
+public class Album extends BaseObject {
     /**
      * <p>The type of the album: <code>album</code>, <code>single</code>, or <code>compilation</code>.</p>
      */
@@ -37,14 +39,6 @@ public class Album {
      * <p>A list of the genres used to classify the album. For example: &quot;Prog Rock&quot; , &quot;Post-Grunge&quot;. (If not yet classified, the array is empty.)</p>
      */
     public java.util.List<String> genres;
-    /**
-     * <p>A link to the Web API endpoint providing full details of the album.</p>
-     */
-    public String href;
-    /**
-     * <p>The Spotify ID for the album.</p>
-     */
-    public String id;
     /**
      * <p>The cover art for the album in various sizes, widest first.</p>
      */
@@ -77,12 +71,4 @@ public class Album {
      * <p>The tracks of the album.</p>
      */
     public Paging<SimplifiedTrack> tracks;
-    /**
-     * <p>The object type: &quot;album&quot;</p>
-     */
-    public String type;
-    /**
-     * <p>The Spotify URI for the album.</p>
-     */
-    public String uri;
 }

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/Artist.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/Artist.java
@@ -1,5 +1,6 @@
 package de.sonallux.spotify.api.models;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.*;
 
 /**
@@ -8,7 +9,8 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
-public class Artist {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Disable deserialization based on @JsonTypeInfo
+public class Artist extends BaseObject {
     /**
      * <p>Known external URLs for this artist.</p>
      */
@@ -22,14 +24,6 @@ public class Artist {
      */
     public java.util.List<String> genres;
     /**
-     * <p>A link to the Web API endpoint providing full details of the artist.</p>
-     */
-    public String href;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify ID</a> for the artist.</p>
-     */
-    public String id;
-    /**
      * <p>Images of the artist in various sizes, widest first.</p>
      */
     public java.util.List<Image> images;
@@ -41,12 +35,4 @@ public class Artist {
      * <p>The popularity of the artist. The value will be between 0 and 100, with 100 being the most popular. The artist's popularity is calculated from the popularity of all the artist's tracks.</p>
      */
     public int popularity;
-    /**
-     * <p>The object type: <code>&quot;artist&quot;</code></p>
-     */
-    public String type;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify URI</a> for the artist.</p>
-     */
-    public String uri;
 }

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/BaseObject.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/BaseObject.java
@@ -1,0 +1,37 @@
+package de.sonallux.spotify.api.models;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Album.class, name = "album"),
+    @JsonSubTypes.Type(value = Artist.class, name = "artist"),
+    @JsonSubTypes.Type(value = Episode.class, name = "episode"),
+    @JsonSubTypes.Type(value = Playlist.class, name = "playlist"),
+    @JsonSubTypes.Type(value = Show.class, name = "show"),
+    @JsonSubTypes.Type(value = Track.class, name = "track"),
+    @JsonSubTypes.Type(value = PrivateUser.class, name = "user"),
+})
+public abstract class BaseObject {
+    /**
+     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify ID</a> for the object.</p>
+     */
+    public String id;
+    /**
+     * <p>The object type.</p>
+     */
+    public String type;
+    /**
+     * <p>A link to the Web API endpoint providing full details of the object.</p>
+     */
+    public String href;
+    /**
+     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify URI</a> for the object.</p>
+     */
+    public String uri;
+}

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/CurrentlyPlaying.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/CurrentlyPlaying.java
@@ -24,7 +24,7 @@ public class CurrentlyPlaying {
     /**
      * <p>The currently playing track or episode. Can be <code>null</code>.</p>
      */
-    public java.util.Map<String, Object> item;
+    public BaseObject item;
     /**
      * <p>Progress into the currently playing track or episode. Can be <code>null</code>.</p>
      */

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/CurrentlyPlayingContext.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/CurrentlyPlayingContext.java
@@ -32,7 +32,7 @@ public class CurrentlyPlayingContext {
     /**
      * <p>The currently playing track or episode. Can be <code>null</code>.</p>
      */
-    public java.util.Map<String, Object> item;
+    public BaseObject item;
     /**
      * <p>Progress into the currently playing track or episode. Can be <code>null</code>.</p>
      */

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/Episode.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/Episode.java
@@ -1,5 +1,6 @@
 package de.sonallux.spotify.api.models;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.*;
 
 /**
@@ -8,7 +9,8 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
-public class Episode {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Disable deserialization based on @JsonTypeInfo
+public class Episode extends BaseObject {
     /**
      * <p>A URL to a 30 second preview (MP3 format) of the episode. <code>null</code> if not available.</p>
      */
@@ -29,14 +31,6 @@ public class Episode {
      * <p>External URLs for this episode.</p>
      */
     public ExternalUrl externalUrls;
-    /**
-     * <p>A link to the Web API endpoint providing full details of the episode.</p>
-     */
-    public String href;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify ID</a> for the episode.</p>
-     */
-    public String id;
     /**
      * <p>The cover art for the episode in various sizes, widest first.</p>
      */
@@ -77,12 +71,4 @@ public class Episode {
      * <p>The show on which the episode belongs.</p>
      */
     public SimplifiedShow show;
-    /**
-     * <p>The object type: &quot;episode&quot;.</p>
-     */
-    public String type;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify URI</a> for the episode.</p>
-     */
-    public String uri;
 }

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/LinkedTrack.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/LinkedTrack.java
@@ -1,5 +1,6 @@
 package de.sonallux.spotify.api.models;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.*;
 
 /**
@@ -8,25 +9,10 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
-public class LinkedTrack {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Disable deserialization based on @JsonTypeInfo
+public class LinkedTrack extends BaseObject {
     /**
      * <p>Known external URLs for this track.</p>
      */
     public ExternalUrl externalUrls;
-    /**
-     * <p>A link to the Web API endpoint providing full details of the track.</p>
-     */
-    public String href;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify ID</a> for the track.</p>
-     */
-    public String id;
-    /**
-     * <p>The object type: &quot;track&quot;.</p>
-     */
-    public String type;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify URI</a> for the track.</p>
-     */
-    public String uri;
 }

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/Playlist.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/Playlist.java
@@ -1,5 +1,6 @@
 package de.sonallux.spotify.api.models;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.*;
 
 /**
@@ -8,7 +9,8 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
-public class Playlist {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Disable deserialization based on @JsonTypeInfo
+public class Playlist extends BaseObject {
     /**
      * <p><code>true</code> if the owner allows other users to modify the playlist.</p>
      */
@@ -25,14 +27,6 @@ public class Playlist {
      * <p>Information about the followers of the playlist.</p>
      */
     public Followers followers;
-    /**
-     * <p>A link to the Web API endpoint providing full details of the playlist.</p>
-     */
-    public String href;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify ID</a> for the playlist.</p>
-     */
-    public String id;
     /**
      * <p>Images for the playlist. The array may be empty or contain up to three images. The images are returned by size in descending order. See <a href="https://developer.spotify.com/documentation/general/guides/working-with-playlists/">Working with Playlists</a>. <em>Note: If returned, the source URL for the image (<code>url</code>) is temporary and will expire in less than a day.</em></p>
      */
@@ -58,12 +52,4 @@ public class Playlist {
      * <p>Information about the tracks of the playlist. Note, a track object may be <code>null</code>. This can happen if a track is no longer available.</p>
      */
     public Paging<PlaylistTrack> tracks;
-    /**
-     * <p>The object type: &quot;playlist&quot;</p>
-     */
-    public String type;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify URI</a> for the playlist.</p>
-     */
-    public String uri;
 }

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/PlaylistTrack.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/PlaylistTrack.java
@@ -24,5 +24,5 @@ public class PlaylistTrack {
     /**
      * <p>Information about the track or episode.</p>
      */
-    public java.util.Map<String, Object> track;
+    public BaseObject track;
 }

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/PrivateUser.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/PrivateUser.java
@@ -1,5 +1,6 @@
 package de.sonallux.spotify.api.models;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.*;
 
 /**
@@ -8,7 +9,8 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
-public class PrivateUser {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Disable deserialization based on @JsonTypeInfo
+public class PrivateUser extends BaseObject {
     /**
      * <p>The country of the user, as set in the user's account profile. An <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2 country code</a>. <em>This field is only available when the current user has granted access to the <a href="https://developer.spotify.com/documentation/general/guides/authorization-guide/#list-of-scopes">user-read-private</a> scope.</em></p>
      */
@@ -34,14 +36,6 @@ public class PrivateUser {
      */
     public Followers followers;
     /**
-     * <p>A link to the Web API endpoint for this user.</p>
-     */
-    public String href;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify user ID</a> for the user.</p>
-     */
-    public String id;
-    /**
      * <p>The user's profile image.</p>
      */
     public java.util.List<Image> images;
@@ -49,12 +43,4 @@ public class PrivateUser {
      * <p>The user's Spotify subscription level: &quot;premium&quot;, &quot;free&quot;, etc. (The subscription level &quot;open&quot; can be considered the same as &quot;free&quot;.) <em>This field is only available when the current user has granted access to the <a href="https://developer.spotify.com/documentation/general/guides/authorization-guide/#list-of-scopes">user-read-private</a> scope.</em></p>
      */
     public String product;
-    /**
-     * <p>The object type: &quot;user&quot;</p>
-     */
-    public String type;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify URI</a> for the user.</p>
-     */
-    public String uri;
 }

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/PublicUser.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/PublicUser.java
@@ -1,5 +1,6 @@
 package de.sonallux.spotify.api.models;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.*;
 
 /**
@@ -8,7 +9,8 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
-public class PublicUser {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Disable deserialization based on @JsonTypeInfo
+public class PublicUser extends BaseObject {
     /**
      * <p>The name displayed on the user's profile. <code>null</code> if not available.</p>
      */
@@ -22,23 +24,7 @@ public class PublicUser {
      */
     public Followers followers;
     /**
-     * <p>A link to the Web API endpoint for this user.</p>
-     */
-    public String href;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify user ID</a> for this user.</p>
-     */
-    public String id;
-    /**
      * <p>The user's profile image.</p>
      */
     public java.util.List<Image> images;
-    /**
-     * <p>The object type: &quot;user&quot;</p>
-     */
-    public String type;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify URI</a> for this user.</p>
-     */
-    public String uri;
 }

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/Show.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/Show.java
@@ -1,5 +1,6 @@
 package de.sonallux.spotify.api.models;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.*;
 
 /**
@@ -8,7 +9,8 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
-public class Show {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Disable deserialization based on @JsonTypeInfo
+public class Show extends BaseObject {
     /**
      * <p>A list of the countries in which the show can be played, identified by their <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a> code.</p>
      */
@@ -34,14 +36,6 @@ public class Show {
      */
     public ExternalUrl externalUrls;
     /**
-     * <p>A link to the Web API endpoint providing full details of the show.</p>
-     */
-    public String href;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify ID</a> for the show.</p>
-     */
-    public String id;
-    /**
      * <p>The cover art for the show in various sizes, widest first.</p>
      */
     public java.util.List<Image> images;
@@ -65,12 +59,4 @@ public class Show {
      * <p>The publisher of the show.</p>
      */
     public String publisher;
-    /**
-     * <p>The object type: &quot;show&quot;.</p>
-     */
-    public String type;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify URI</a> for the show.</p>
-     */
-    public String uri;
 }

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/SimplifiedAlbum.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/SimplifiedAlbum.java
@@ -1,5 +1,6 @@
 package de.sonallux.spotify.api.models;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.*;
 
 /**
@@ -8,7 +9,8 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
-public class SimplifiedAlbum {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Disable deserialization based on @JsonTypeInfo
+public class SimplifiedAlbum extends BaseObject {
     /**
      * <p>The field is present when getting an artist's albums. Possible values are &quot;album&quot;, &quot;single&quot;, &quot;compilation&quot;, &quot;appears_on&quot;. Compare to album_type this field represents relationship between the artist and the album.</p>
      */
@@ -30,14 +32,6 @@ public class SimplifiedAlbum {
      */
     public ExternalUrl externalUrls;
     /**
-     * <p>A link to the Web API endpoint providing full details of the album.</p>
-     */
-    public String href;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify ID</a> for the album.</p>
-     */
-    public String id;
-    /**
      * <p>The cover art for the album in various sizes, widest first.</p>
      */
     public java.util.List<Image> images;
@@ -57,12 +51,4 @@ public class SimplifiedAlbum {
      * <p>Included in the response when a content restriction is applied. See <a href="https://developer.spotify.com/documentation/web-api/reference/#object-albumrestrictionobject">Restriction Object</a> for more details.</p>
      */
     public AlbumRestriction restrictions;
-    /**
-     * <p>The object type: &quot;album&quot;</p>
-     */
-    public String type;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify URI</a> for the album.</p>
-     */
-    public String uri;
 }

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/SimplifiedArtist.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/SimplifiedArtist.java
@@ -1,5 +1,6 @@
 package de.sonallux.spotify.api.models;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.*;
 
 /**
@@ -8,29 +9,14 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
-public class SimplifiedArtist {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Disable deserialization based on @JsonTypeInfo
+public class SimplifiedArtist extends BaseObject {
     /**
      * <p>Known external URLs for this artist.</p>
      */
     public ExternalUrl externalUrls;
     /**
-     * <p>A link to the Web API endpoint providing full details of the artist.</p>
-     */
-    public String href;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify ID</a> for the artist.</p>
-     */
-    public String id;
-    /**
      * <p>The name of the artist.</p>
      */
     public String name;
-    /**
-     * <p>The object type: <code>&quot;artist&quot;</code></p>
-     */
-    public String type;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify URI</a> for the artist.</p>
-     */
-    public String uri;
 }

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/SimplifiedEpisode.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/SimplifiedEpisode.java
@@ -1,5 +1,6 @@
 package de.sonallux.spotify.api.models;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.*;
 
 /**
@@ -8,7 +9,8 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
-public class SimplifiedEpisode {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Disable deserialization based on @JsonTypeInfo
+public class SimplifiedEpisode extends BaseObject {
     /**
      * <p>A URL to a 30 second preview (MP3 format) of the episode. <code>null</code> if not available.</p>
      */
@@ -29,14 +31,6 @@ public class SimplifiedEpisode {
      * <p>External URLs for this episode.</p>
      */
     public ExternalUrl externalUrls;
-    /**
-     * <p>A link to the Web API endpoint providing full details of the episode.</p>
-     */
-    public String href;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify ID</a> for the episode.</p>
-     */
-    public String id;
     /**
      * <p>The cover art for the episode in various sizes, widest first.</p>
      */
@@ -73,12 +67,4 @@ public class SimplifiedEpisode {
      * <p>The user's most recent position in the episode. Set if the supplied access token is a user token and has the scope 'user-read-playback-position'.</p>
      */
     public ResumePoint resumePoint;
-    /**
-     * <p>The object type: &quot;episode&quot;.</p>
-     */
-    public String type;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify URI</a> for the episode.</p>
-     */
-    public String uri;
 }

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/SimplifiedPlaylist.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/SimplifiedPlaylist.java
@@ -1,5 +1,6 @@
 package de.sonallux.spotify.api.models;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.*;
 
 /**
@@ -8,7 +9,8 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
-public class SimplifiedPlaylist {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Disable deserialization based on @JsonTypeInfo
+public class SimplifiedPlaylist extends BaseObject {
     /**
      * <p><code>true</code> if the owner allows other users to modify the playlist.</p>
      */
@@ -21,14 +23,6 @@ public class SimplifiedPlaylist {
      * <p>Known external URLs for this playlist.</p>
      */
     public ExternalUrl externalUrls;
-    /**
-     * <p>A link to the Web API endpoint providing full details of the playlist.</p>
-     */
-    public String href;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify ID</a> for the playlist.</p>
-     */
-    public String id;
     /**
      * <p>Images for the playlist. The array may be empty or contain up to three images. The images are returned by size in descending order. See <a href="https://developer.spotify.com/documentation/general/guides/working-with-playlists/">Working with Playlists</a>. <em>Note: If returned, the source URL for the image (<code>url</code>) is temporary and will expire in less than a day.</em></p>
      */
@@ -54,12 +48,4 @@ public class SimplifiedPlaylist {
      * <p>A collection containing a link ( <code>href</code> ) to the Web API endpoint where full details of the playlist's tracks can be retrieved, along with the <code>total</code> number of tracks in the playlist. Note, a track object may be <code>null</code>. This can happen if a track is no longer available.</p>
      */
     public PlaylistTracksRef tracks;
-    /**
-     * <p>The object type: &quot;playlist&quot;</p>
-     */
-    public String type;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify URI</a> for the playlist.</p>
-     */
-    public String uri;
 }

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/SimplifiedShow.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/SimplifiedShow.java
@@ -1,5 +1,6 @@
 package de.sonallux.spotify.api.models;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.*;
 
 /**
@@ -8,7 +9,8 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
-public class SimplifiedShow {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Disable deserialization based on @JsonTypeInfo
+public class SimplifiedShow extends BaseObject {
     /**
      * <p>A list of the countries in which the show can be played, identified by their <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a> code.</p>
      */
@@ -29,14 +31,6 @@ public class SimplifiedShow {
      * <p>External URLs for this show.</p>
      */
     public ExternalUrl externalUrls;
-    /**
-     * <p>A link to the Web API endpoint providing full details of the show.</p>
-     */
-    public String href;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify ID</a> for the show.</p>
-     */
-    public String id;
     /**
      * <p>The cover art for the show in various sizes, widest first.</p>
      */
@@ -61,12 +55,4 @@ public class SimplifiedShow {
      * <p>The publisher of the show.</p>
      */
     public String publisher;
-    /**
-     * <p>The object type: &quot;show&quot;.</p>
-     */
-    public String type;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify URI</a> for the show.</p>
-     */
-    public String uri;
 }

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/SimplifiedTrack.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/SimplifiedTrack.java
@@ -1,5 +1,6 @@
 package de.sonallux.spotify.api.models;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.*;
 
 /**
@@ -8,7 +9,8 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
-public class SimplifiedTrack {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Disable deserialization based on @JsonTypeInfo
+public class SimplifiedTrack extends BaseObject {
     /**
      * <p>The artists who performed the track. Each artist object includes a link in <code>href</code> to more detailed information about the artist.</p>
      */
@@ -33,14 +35,6 @@ public class SimplifiedTrack {
      * <p>External URLs for this track.</p>
      */
     public ExternalUrl externalUrls;
-    /**
-     * <p>A link to the Web API endpoint providing full details of the track.</p>
-     */
-    public String href;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify ID</a> for the track.</p>
-     */
-    public String id;
     /**
      * <p>Whether or not the track is from a local file.</p>
      */
@@ -69,12 +63,4 @@ public class SimplifiedTrack {
      * <p>The number of the track. If an album has several discs, the track number is the number on the specified disc.</p>
      */
     public int trackNumber;
-    /**
-     * <p>The object type: &quot;track&quot;.</p>
-     */
-    public String type;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify URI</a> for the track.</p>
-     */
-    public String uri;
 }

--- a/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/Track.java
+++ b/spotify-web-api-java/src/main/generated/de/sonallux/spotify/api/models/Track.java
@@ -1,5 +1,6 @@
 package de.sonallux.spotify.api.models;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.*;
 
 /**
@@ -8,7 +9,8 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
-public class Track {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Disable deserialization based on @JsonTypeInfo
+public class Track extends BaseObject {
     /**
      * <p>The album on which the track appears. The album object includes a link in <code>href</code> to full information about the album.</p>
      */
@@ -41,14 +43,6 @@ public class Track {
      * <p>Known external URLs for this track.</p>
      */
     public ExternalUrl externalUrls;
-    /**
-     * <p>A link to the Web API endpoint providing full details of the track.</p>
-     */
-    public String href;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify ID</a> for the track.</p>
-     */
-    public String id;
     /**
      * <p>Whether or not the track is from a local file.</p>
      */
@@ -83,12 +77,4 @@ public class Track {
      * <p>The number of the track. If an album has several discs, the track number is the number on the specified disc.</p>
      */
     public int trackNumber;
-    /**
-     * <p>The object type: &quot;track&quot;.</p>
-     */
-    public String type;
-    /**
-     * <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify URI</a> for the track.</p>
-     */
-    public String uri;
 }


### PR DESCRIPTION
- Adds support for generating a shared super object type (fixes #7)
- Add better union type handling in generator-java (fixes #37)