### PR TITLE
Add missing `ids` body parameter

### DIFF
--- a/spotify-web-api-core/src/main/resources/spotify-web-api.yml
+++ b/spotify-web-api-core/src/main/resources/spotify-web-api.yml
@@ -3752,6 +3752,14 @@ categories:
             \ their account in the [account settings](https://www.spotify.com/se/account/overview/)."
           type: String
           required: false
+        - location: BODY
+          name: ids
+          description: "A JSON array of the [Spotify IDs](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids).\
+            \  \nA maximum of 50 items can be specified in one request. *Note: if\
+            \ the `ids` parameter is present in the query string, any IDs listed here\
+            \ in the body will be ignored.*"
+          type: "Array[String]"
+          required: false
         responseDescription: "On success, the HTTP status code in the response header\
           \ is `200` OK.\nOn error, the header status code is an [error code](https://developer.spotify.com/documentation/web-api/#response-status-codes)\
           \ and the response body contains an [error object](https://developer.spotify.com/documentation/web-api/#error-details).\
@@ -3931,6 +3939,14 @@ categories:
             \ Maximum: 50 IDs."
           type: String
           required: true
+        - location: BODY
+          name: ids
+          description: "A JSON array of the [Spotify IDs](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids).\
+            \  \nA maximum of 50 items can be specified in one request. *Note: if\
+            \ the `ids` parameter is present in the query string, any IDs listed here\
+            \ in the body will be ignored.*"
+          type: "Array[String]"
+          required: false
         responseDescription: "On success, the HTTP status code in the response header\
           \ is `200` OK. On error, the header status code is an [error code](https://developer.spotify.com/documentation/web-api/#response-status-codes)\
           \ and the response body contains an [error object](https://developer.spotify.com/documentation/web-api/#error-details).\

--- a/spotify-web-api-generator-open-api/spotify-web-api-openapi.yml
+++ b/spotify-web-api-generator-open-api/spotify-web-api-openapi.yml
@@ -2695,6 +2695,21 @@ paths:
         required: true
         schema:
           type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ids:
+                  type: array
+                  description: "A JSON array of the [Spotify IDs](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids).\
+                    \  \nA maximum of 50 items can be specified in one request. *Note:\
+                    \ if the `ids` parameter is present in the query string, any IDs\
+                    \ listed here in the body will be ignored.*"
+                  items:
+                    type: string
+        required: false
       responses:
         default:
           $ref: '#/components/responses/ErrorResponse'
@@ -2747,6 +2762,21 @@ paths:
         required: false
         schema:
           type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ids:
+                  type: array
+                  description: "A JSON array of the [Spotify IDs](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids).\
+                    \  \nA maximum of 50 items can be specified in one request. *Note:\
+                    \ if the `ids` parameter is present in the query string, any IDs\
+                    \ listed here in the body will be ignored.*"
+                  items:
+                    type: string
+        required: false
       responses:
         default:
           $ref: '#/components/responses/ErrorResponse'

--- a/spotify-web-api-parser/response-types.yml
+++ b/spotify-web-api-parser/response-types.yml
@@ -65,7 +65,7 @@ category-library:
     - type: "Array[Boolean]"
       status: 200
   endpoint-get-users-saved-episodes:
-    md5Hash: 8c34757f341b78f13871c0642765aa84
+    md5Hash: 80f3e189edc6742d8348ebee029f2a6d
     responseTypes:
     - type: "PagingObject[SavedEpisodeObject]"
       status: 200

--- a/spotify-web-api-parser/src/main/java/de/sonallux/spotify/parser/ApiEndpointParser.java
+++ b/spotify-web-api-parser/src/main/java/de/sonallux/spotify/parser/ApiEndpointParser.java
@@ -59,20 +59,21 @@ class ApiEndpointParser {
         try {
             if (isInteractive) {
                 responseTypeMapper.update(new ArrayList<>(categories.values()));
-                responseTypeMapper.save();
             }
 
             for (var category : categories.values()) {
                 for (var endpoint : category.getEndpointList()) {
-                    var endpointResponse = responseTypeMapper.getEndpointResponse(category.getId(), endpoint.getId());
-                    if (endpointResponse == null || endpointResponse.getResponseTypes().isEmpty()) {
+                    var responseTypes = responseTypeMapper.getEndpointResponseTypes(category.getId(), endpoint);
+                    if (responseTypes == null || responseTypes.isEmpty()) {
                         log.warn("Missing response type in {} for {} {} with response: \n{}\n", category.getId(),
                                 endpoint.getHttpMethod(), endpoint.getId(), endpoint.getResponseDescription());
                         continue;
                     }
-                    endpoint.setResponseTypes(endpointResponse.getResponseTypes());
+                    endpoint.setResponseTypes(responseTypes);
                 }
             }
+
+            responseTypeMapper.save();
         } catch (IOException e) {
             log.error("Failed to load missing response types", e);
         }

--- a/spotify-web-api-parser/src/main/java/de/sonallux/spotify/parser/Html2Markdown.java
+++ b/spotify-web-api-parser/src/main/java/de/sonallux/spotify/parser/Html2Markdown.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class Html2Markdown {
+class Html2Markdown {
 
     private static final FlexmarkHtmlConverter CONVERTER;
 
@@ -27,11 +27,11 @@ public class Html2Markdown {
                 .build();
     }
 
-    public static String convert(Node node) {
+    static String convert(Node node) {
         return CONVERTER.convert(node).trim();
     }
 
-    public static String convert(List<? extends Node> nodes) {
+    static String convert(List<? extends Node> nodes) {
         return nodes.stream()
                 .map(CONVERTER::convert)
                 .collect(Collectors.joining("\n"))

--- a/spotify-web-api-parser/src/main/java/de/sonallux/spotify/parser/ResponseTypeMapper.java
+++ b/spotify-web-api-parser/src/main/java/de/sonallux/spotify/parser/ResponseTypeMapper.java
@@ -21,14 +21,14 @@ import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
 @Slf4j
-public class ResponseTypeMapper {
+class ResponseTypeMapper {
 
     private final Path responseTypesFile;
     private final Map<String, Map<String, EndpointResponse>> responseTypes;
     private final MessageDigest md5Digest;
     private final ObjectMapper objectMapper;
 
-    public ResponseTypeMapper(Path responseTypesFile) throws IOException, NoSuchAlgorithmException {
+    ResponseTypeMapper(Path responseTypesFile) throws IOException, NoSuchAlgorithmException {
         this.responseTypesFile = responseTypesFile;
         this.objectMapper = Yaml.create();
         this.md5Digest = MessageDigest.getInstance("MD5");
@@ -41,7 +41,7 @@ public class ResponseTypeMapper {
         }
     }
 
-    public List<SpotifyWebApiEndpoint.ResponseType> getEndpointResponseTypes(String categoryId, SpotifyWebApiEndpoint endpoint) {
+    List<SpotifyWebApiEndpoint.ResponseType> getEndpointResponseTypes(String categoryId, SpotifyWebApiEndpoint endpoint) {
         var endpointResponse = getEndpointResponse(categoryId, endpoint.getId());
         if (endpointResponse == null) {
             return null;
@@ -54,13 +54,13 @@ public class ResponseTypeMapper {
         return endpointResponse.getResponseTypes();
     }
 
-    public void save() throws IOException {
+    void save() throws IOException {
         try (var outputStream = Files.newOutputStream(this.responseTypesFile)) {
             objectMapper.writeValue(outputStream, responseTypes);
         }
     }
 
-    public void update(List<SpotifyWebApiCategory> categories) {
+    void update(List<SpotifyWebApiCategory> categories) {
         var scanner = new Scanner(System.in);
         for (var category : categories) {
             for (var endpoint : category.getEndpointList()) {
@@ -150,7 +150,7 @@ public class ResponseTypeMapper {
     @Setter
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class EndpointResponse {
+    static class EndpointResponse {
         private String md5Hash;
         private List<SpotifyWebApiEndpoint.ResponseType> responseTypes = new ArrayList<>();
     }


### PR DESCRIPTION
The endpoints endpoint-save-shows-user and endpoint-remove-shows-user are missing the optional `ids` body parameter. 

The `ResponseTypeMapper` does now always update the endpoint hashes even in non-interactive mode.

Fixes #70