### PR TITLE
Fix tracks property in RecommendationsObject

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.sonallux.spotify</groupId>
     <artifactId>spotify-web-api-parent</artifactId>
-    <version>2021.6.18</version>
+    <version>2021.6.30</version>
     <packaging>pom</packaging>
 
     <name>spotify-web-api-parent</name>

--- a/spotify-web-api-core/pom.xml
+++ b/spotify-web-api-core/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>de.sonallux.spotify</groupId>
         <artifactId>spotify-web-api-parent</artifactId>
-        <version>2021.6.18</version>
+        <version>2021.6.30</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>spotify-web-api-core</artifactId>
-    <version>2021.6.18</version>
+    <version>2021.6.30</version>
     <packaging>jar</packaging>
 
     <name>spotify-web-api-core</name>

--- a/spotify-web-api-core/src/main/resources/spotify-web-api.yml
+++ b/spotify-web-api-core/src/main/resources/spotify-web-api.yml
@@ -1031,8 +1031,8 @@ objects:
       type: "Array[RecommendationSeedObject]"
       description: "An array of [recommendation seed objects](https://developer.spotify.com/documentation/web-api/reference/#object-recommendationseedobject)."
     - name: tracks
-      type: "Array[SimplifiedTrackObject]"
-      description: "An array of [track object (simplified)](https://developer.spotify.com/documentation/web-api/reference/#object-simplifiedtrackobject)\
+      type: "Array[TrackObject]"
+      description: "An array of [track object](https://developer.spotify.com/documentation/web-api/reference/#object-trackobject)\
         \ ordered according to the parameters supplied."
   ResumePointObject:
     name: ResumePointObject

--- a/spotify-web-api-generator-open-api/pom.xml
+++ b/spotify-web-api-generator-open-api/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>de.sonallux.spotify</groupId>
         <artifactId>spotify-web-api-parent</artifactId>
-        <version>2021.6.18</version>
+        <version>2021.6.30</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>spotify-web-api-generator-open-api</artifactId>
-    <version>2021.6.18</version>
+    <version>2021.6.30</version>
     <packaging>jar</packaging>
 
     <name>spotify-web-api-generator-open-api</name>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>de.sonallux.spotify</groupId>
             <artifactId>spotify-web-api-core</artifactId>
-            <version>2021.6.18</version>
+            <version>2021.6.30</version>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>

--- a/spotify-web-api-generator-open-api/spotify-web-api-openapi.yml
+++ b/spotify-web-api-generator-open-api/spotify-web-api-openapi.yml
@@ -4,7 +4,7 @@ info:
   contact:
     name: sonallux
     url: https://github.com/sonallux/spotify-web-api
-  version: 2021.6.18
+  version: 2021.6.30
 externalDocs:
   description: Find more info on the official Spotify Web API Reference
   url: https://developer.spotify.com/documentation/web-api/reference
@@ -6852,10 +6852,10 @@ components:
             $ref: '#/components/schemas/RecommendationSeedObject'
         tracks:
           type: array
-          description: "An array of [track object (simplified)](https://developer.spotify.com/documentation/web-api/reference/#object-simplifiedtrackobject)\
+          description: "An array of [track object](https://developer.spotify.com/documentation/web-api/reference/#object-trackobject)\
             \ ordered according to the parameters supplied."
           items:
-            $ref: '#/components/schemas/SimplifiedTrackObject'
+            $ref: '#/components/schemas/TrackObject'
       externalDocs:
         description: Find more info on the official Spotify Web API Reference
         url: https://developer.spotify.com/documentation/web-api/reference/#object-recommendationsobject

--- a/spotify-web-api-parser/pom.xml
+++ b/spotify-web-api-parser/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>de.sonallux.spotify</groupId>
         <artifactId>spotify-web-api-parent</artifactId>
-        <version>2021.6.18</version>
+        <version>2021.6.30</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>spotify-web-api-parser</artifactId>
-    <version>2021.6.18</version>
+    <version>2021.6.30</version>
     <packaging>jar</packaging>
 
     <name>spotify-web-api-parser</name>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>de.sonallux.spotify</groupId>
             <artifactId>spotify-web-api-core</artifactId>
-            <version>2021.6.18</version>
+            <version>2021.6.30</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>

--- a/spotify-web-api-parser/src/main/java/de/sonallux/spotify/parser/ApiObjectFixes.java
+++ b/spotify-web-api-parser/src/main/java/de/sonallux/spotify/parser/ApiObjectFixes.java
@@ -15,6 +15,7 @@ class ApiObjectFixes {
         fixTracksTypeInPlaylistObject(objects);
         fixTracksTypeInAlbumObject(objects);
         fixEpisodesTypeInShowObject(objects);
+        fixTracksPropertyInRecommendationsObject(objects);
     }
 
     private static void fixLinkedTrackObjectReferenceInTrackObject(SortedMap<String, SpotifyWebApiObject> objects) {
@@ -62,6 +63,22 @@ class ApiObjectFixes {
             log.warn("ShowObject: wrong type of property episodes has been fixed");
         } else {
             tracksProperty.setType("PagingObject[SimplifiedEpisodeObject]");
+        }
+    }
+
+    private static void fixTracksPropertyInRecommendationsObject(SortedMap<String, SpotifyWebApiObject> objects) {
+        var tracksProperty = objects.get("RecommendationsObject")
+            .getProperties().stream()
+            .filter(p -> "tracks".equals(p.getName()) && "Array[SimplifiedTrackObject]".equals(p.getType()))
+            .findFirst().orElse(null);
+        if (tracksProperty == null){
+            log.warn("RecommendationsObject: wrong type of tracks property has been fixed");
+        } else {
+            tracksProperty.setType("Array[TrackObject]");
+            var newDescription = tracksProperty.getDescription()
+                .replace(" (simplified)", "")
+                .replace("object-simplifiedtrackobject", "object-trackobject");
+            tracksProperty.setDescription(newDescription);
         }
     }
 


### PR DESCRIPTION
The get recommendations endpoint is returning the full TrackObject and not a SimplifiedTrackObject even though it is documented that way in the [Web API Reference](https://developer.spotify.com/documentation/web-api/reference/#object-recommendationsobject).

Fix #82