### PR TITLE
Update of Spotify's OpenAPI definition

### DIFF
--- a/fixed-spotify-open-api.yml
+++ b/fixed-spotify-open-api.yml
@@ -3053,7 +3053,6 @@ paths:
                     Optional. Spotify URI of the context to play.
                     Valid contexts are albums, artists & playlists.
                     {context_uri:"spotify:album:1Je1IMUlBXcx1Fz0WE7oPT"}
-                  additionalProperties: true
                 uris:
                   type: array
                   description: |
@@ -3070,8 +3069,8 @@ paths:
                   additionalProperties: true
                 position_ms:
                   type: integer
-                  description: integer
-                  additionalProperties: true
+                  description: |
+                    Indicates from what position to start playback. Must be a positive number. Passing in a position that is greater than the length of the track will cause the player to start playing the next song.
       responses:
         "204":
           description: Playback started

--- a/fixed-spotify-open-api.yml
+++ b/fixed-spotify-open-api.yml
@@ -3050,22 +3050,28 @@ paths:
                 context_uri:
                   type: string
                   description: |
-                    Spotify URI of the context to play. Valid contexts are albums, artists, playlists. Example: {"context_uri": "spotify:album:1Je1IMUlBXcx1Fz0WE7oPT"}
+                    Optional. Spotify URI of the context to play.
+                    Valid contexts are albums, artists & playlists.
+                    {context_uri:"spotify:album:1Je1IMUlBXcx1Fz0WE7oPT"}
+                  additionalProperties: true
                 uris:
                   type: array
                   description: |
-                    A JSON array of the Spotify track URIs to play. For example: {"uris": ["spotify:track:4iV5W9uYEdYUVa79Axb7Rh", "spotify:track:1301WleyT98MSxVHPZCA6M"]}
+                    Optional. A JSON array of the Spotify track URIs to play.
+                    For example: {"uris": ["spotify:track:4iV5W9uYEdYUVa79Axb7Rh", "spotify:track:1301WleyT98MSxVHPZCA6M"]}
                   items:
                     type: string
                 offset:
                   type: object
                   description: |
-                    Indicates from where in the context playback should start. Only available when "context_uri" corresponds to an album or playlist object, or when the uris parameter is used. "position" is zero based and can't be negative. Example: "offset": {"position": 5} "uri" is a string representing the uri of the item to start at. Example: "offset": {"uri": "spotify:track:1301WleyT98MSxVHPZCA6M"}
+                    Optional. Indicates from where in the context playback should start. Only available when context_uri corresponds to an album or playlist object
+                    "position" is zero based and can’t be negative. Example: "offset": {"position": 5}
+                    "uri" is a string representing the uri of the item to start at. Example: "offset": {"uri": "spotify:track:1301WleyT98MSxVHPZCA6M"}
                   additionalProperties: true
                 position_ms:
                   type: integer
-                  description: |
-                    Indicates from what position to start playback. Must be a positive number. Passing in a position that is greater than the length of the track will cause the player to start playing the next song.
+                  description: integer
+                  additionalProperties: true
       responses:
         "204":
           description: Playback started

--- a/official-spotify-open-api.yml
+++ b/official-spotify-open-api.yml
@@ -3218,17 +3218,23 @@ paths:
                 context_uri:
                   type: string
                   description: |
-                    string
+                    Optional. Spotify URI of the context to play.
+                    Valid contexts are albums, artists & playlists.
+                    {context_uri:"spotify:album:1Je1IMUlBXcx1Fz0WE7oPT"}
                   additionalProperties: true
                 uris:
                   type: array
                   description: |
-                    Array of URIs
+                    Optional. A JSON array of the Spotify track URIs to play.
+                    For example: {"uris": ["spotify:track:4iV5W9uYEdYUVa79Axb7Rh", "spotify:track:1301WleyT98MSxVHPZCA6M"]}
                   items:
                     type: string
                 offset:
                   type: object
-                  description: object
+                  description: |
+                    Optional. Indicates from where in the context playback should start. Only available when context_uri corresponds to an album or playlist object
+                    "position" is zero based and can’t be negative. Example: "offset": {"position": 5}
+                    "uri" is a string representing the uri of the item to start at. Example: "offset": {"uri": "spotify:track:1301WleyT98MSxVHPZCA6M"}
                   additionalProperties: true
                 position_ms:
                   type: integer

--- a/spotify-web-api-open-api/src/main/resources/patches/path-put-start-a-users-playback.yml
+++ b/spotify-web-api-open-api/src/main/resources/patches/path-put-start-a-users-playback.yml
@@ -6,29 +6,6 @@ operations:
   - op: delete
     path: "$.paths./me/player/play.put.requestBody.content.application/json.schema.properties.context_uri.additionalProperties"
   - op: test
-    path: "$.paths./me/player/play.put.requestBody.content.application/json.schema.properties.context_uri.description"
-    value: |
-      string
-  - op: set
-    path: "$.paths./me/player/play.put.requestBody.content.application/json.schema.properties.context_uri.description"
-    value: |
-      Spotify URI of the context to play. Valid contexts are albums, artists, playlists. Example: {"context_uri": "spotify:album:1Je1IMUlBXcx1Fz0WE7oPT"}
-  - op: test
-    path: "$.paths./me/player/play.put.requestBody.content.application/json.schema.properties.uris.description"
-    value: |
-      Array of URIs
-  - op: set
-    path: "$.paths./me/player/play.put.requestBody.content.application/json.schema.properties.uris.description"
-    value: |
-      A JSON array of the Spotify track URIs to play. For example: {"uris": ["spotify:track:4iV5W9uYEdYUVa79Axb7Rh", "spotify:track:1301WleyT98MSxVHPZCA6M"]}
-  - op: test
-    path: "$.paths./me/player/play.put.requestBody.content.application/json.schema.properties.offset.description"
-    value: object
-  - op: set
-    path: "$.paths./me/player/play.put.requestBody.content.application/json.schema.properties.offset.description"
-    value: |
-      Indicates from where in the context playback should start. Only available when "context_uri" corresponds to an album or playlist object, or when the uris parameter is used. "position" is zero based and can't be negative. Example: "offset": {"position": 5} "uri" is a string representing the uri of the item to start at. Example: "offset": {"uri": "spotify:track:1301WleyT98MSxVHPZCA6M"}
-  - op: test
     path: "$.paths./me/player/play.put.requestBody.content.application/json.schema.properties.position_ms.additionalProperties"
     value: true
   - op: delete


### PR DESCRIPTION
Automated update of Spotify's OpenAPI definition

Generated by [this workflow run](https://github.com/sonallux/spotify-web-api/actions/runs/2559299603).