### PR TITLE
Update of Spotify's OpenAPI definition

### DIFF
--- a/fixed-spotify-open-api.yml
+++ b/fixed-spotify-open-api.yml
@@ -4693,7 +4693,7 @@ components:
           type: string
           description: "off, track, context"
         shuffle_state:
-          type: string
+          type: boolean
           description: If shuffle is on or off.
         context:
           allOf:

--- a/official-spotify-open-api.yml
+++ b/official-spotify-open-api.yml
@@ -4711,7 +4711,7 @@ components:
           type: string
           description: off, track, context
         shuffle_state:
-          type: string
+          type: boolean
           description: If shuffle is on or off.
         context:
           allOf:


### PR DESCRIPTION
Automated update of Spotify's OpenAPI definition

Generated by [this workflow run](https://github.com/sonallux/spotify-web-api/actions/runs/3921452752).