### PR TITLE
Update of Spotify's OpenAPI definition

### DIFF
--- a/fixed-spotify-open-api.yml
+++ b/fixed-spotify-open-api.yml
@@ -1719,6 +1719,7 @@ paths:
       description: |
         Create a playlist for a Spotify user. (The playlist will be empty until
         you [add tracks](/documentation/web-api/reference/add-tracks-to-playlist).)
+        Each user is generally limited to a maximum of 11000 playlists.
       parameters:
       - $ref: '#/components/parameters/PathUserId'
       requestBody:

--- a/official-spotify-open-api.yml
+++ b/official-spotify-open-api.yml
@@ -1773,6 +1773,7 @@ paths:
       description: |
         Create a playlist for a Spotify user. (The playlist will be empty until
         you [add tracks](/documentation/web-api/reference/add-tracks-to-playlist).)
+        Each user is generally limited to a maximum of 11000 playlists.
       parameters:
         - $ref: '#/components/parameters/PathUserId'
       requestBody:


### PR DESCRIPTION
Automated update of Spotify's OpenAPI definition

Generated by [this workflow run](https://github.com/sonallux/spotify-web-api/actions/runs/6400817315).