### PR TITLE
Update of Spotify's OpenAPI definition

### DIFF
--- a/fixed-spotify-open-api.yml
+++ b/fixed-spotify-open-api.yml
@@ -2337,7 +2337,7 @@ paths:
       - Tracks
       operationId: get-several-audio-features
       summary: |
-        Get Tracks' Audio Features
+        Get Several Tracks' Audio Features
       description: |
         Get audio features for multiple tracks based on their Spotify IDs.
       parameters:

--- a/official-spotify-open-api.yml
+++ b/official-spotify-open-api.yml
@@ -2410,7 +2410,7 @@ paths:
       x-spotify-policy-list:
         - $ref: '#/components/x-spotify-policy/policies/MachineLearning'
       summary: |
-        Get Tracks' Audio Features
+        Get Several Tracks' Audio Features
       description: |
         Get audio features for multiple tracks based on their Spotify IDs.
       parameters:


### PR DESCRIPTION
Automated update of Spotify's OpenAPI definition

Generated by [this workflow run](https://github.com/sonallux/spotify-web-api/actions/runs/7509722869).