### PR TITLE
Update of Spotify's OpenAPI definition

### DIFF
--- a/fixed-spotify-open-api.yml
+++ b/fixed-spotify-open-api.yml
@@ -1830,33 +1830,14 @@ paths:
       description: |
         Get a list of Spotify featured playlists (shown, for example, on a Spotify player's 'Browse' tab).
       parameters:
-      - name: country
-        required: false
-        in: query
-        schema:
-          title: Country
-          description: |
-            A country: an [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). Provide this parameter if you want the list of returned items to be relevant to a particular country. If omitted, the returned items will be relevant to all countries.
-          example: SE
-          type: string
       - name: locale
         required: false
         in: query
         schema:
           title: Locale
           description: |
-            The desired language, consisting of a lowercase [ISO 639-1 language code](http://en.wikipedia.org/wiki/ISO_639-1) and an uppercase [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2), joined by an underscore. For example: `es_MX`, meaning "Spanish (Mexico)". Provide this parameter if you want the results returned in a particular language (where available). <br/>
-            _**Note**: if `locale` is not supplied, or if the specified language is not available, all strings will be returned in the Spotify default language (American English). The `locale` parameter, combined with the `country` parameter, may give odd results if not carefully matched. For example `country=SE&locale=de_DE` will return a list of categories relevant to Sweden but as German language strings._
+            The desired language, consisting of an [ISO 639-1](http://en.wikipedia.org/wiki/ISO_639-1) language code and an [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2), joined by an underscore. For example: `es_MX`, meaning &quot;Spanish (Mexico)&quot;. Provide this parameter if you want the category strings returned in a particular language.<br/> _**Note**: if `locale` is not supplied, or if the specified language is not available, the category strings returned will be in the Spotify default language (American English)._
           example: sv_SE
-          type: string
-      - name: timestamp
-        required: false
-        in: query
-        schema:
-          title: Timestamp
-          description: |
-            A timestamp in [ISO 8601 format](http://en.wikipedia.org/wiki/ISO_8601): `yyyy-MM-ddTHH:mm:ss`. Use this parameter to specify the user's local time to get results tailored for that specific date and time in the day. If not provided, the response defaults to the current UTC time. Example: "2014-10-23T09:00:00" for a user whose local time is 9AM. If there were no featured playlists (or there is no data) at the specified time, the response will revert to the current UTC time.
-          example: 2014-10-23T09:00:00
           type: string
       - $ref: '#/components/parameters/QueryLimit'
       - $ref: '#/components/parameters/QueryOffset'
@@ -1881,23 +1862,13 @@ paths:
       description: |
         Get a list of categories used to tag items in Spotify (on, for example, the Spotify player’s “Browse” tab).
       parameters:
-      - name: country
-        required: false
-        in: query
-        schema:
-          title: Country
-          description: |
-            A country: an [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). Provide this parameter if you want to narrow the list of returned categories to those relevant to a particular country. If omitted, the returned items will be globally relevant.
-          example: SE
-          type: string
       - name: locale
         required: false
         in: query
         schema:
           title: Locale
           description: |
-            The desired language, consisting of an [ISO 639-1](http://en.wikipedia.org/wiki/ISO_639-1) language code and an [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2), joined by an underscore. For example: `es_MX`, meaning "Spanish (Mexico)". Provide this parameter if you want the category metadata returned in a particular language. <br/>
-            _**Note**: if `locale` is not supplied, or if the specified language is not available, all strings will be returned in the Spotify default language (American English). The `locale` parameter, combined with the `country` parameter, may give odd results if not carefully matched. For example `country=SE&locale=de_DE` will return a list of categories relevant to Sweden but as German language strings._
+            The desired language, consisting of an [ISO 639-1](http://en.wikipedia.org/wiki/ISO_639-1) language code and an [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2), joined by an underscore. For example: `es_MX`, meaning &quot;Spanish (Mexico)&quot;. Provide this parameter if you want the category strings returned in a particular language.<br/> _**Note**: if `locale` is not supplied, or if the specified language is not available, the category strings returned will be in the Spotify default language (American English)._
           example: sv_SE
           type: string
       - $ref: '#/components/parameters/QueryLimit'
@@ -1931,15 +1902,6 @@ paths:
           description: |
             The [Spotify category ID](/documentation/web-api/concepts/spotify-uris-ids) for the category.
           example: dinner
-          type: string
-      - name: country
-        required: false
-        in: query
-        schema:
-          title: Country
-          description: |
-            A country: an [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). Provide this parameter to ensure that the category exists for a particular country.
-          example: SE
           type: string
       - name: locale
         required: false
@@ -1980,15 +1942,6 @@ paths:
           description: |
             The [Spotify category ID](/documentation/web-api/concepts/spotify-uris-ids) for the category.
           example: dinner
-          type: string
-      - name: country
-        required: false
-        in: query
-        schema:
-          title: Country
-          description: |
-            A country: an [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). Provide this parameter to ensure that the category exists for a particular country.
-          example: SE
           type: string
       - $ref: '#/components/parameters/QueryLimit'
       - $ref: '#/components/parameters/QueryOffset'
@@ -2069,15 +2022,6 @@ paths:
       description: |
         Get a list of new album releases featured in Spotify (shown, for example, on a Spotify player’s “Browse” tab).
       parameters:
-      - name: country
-        required: false
-        in: query
-        schema:
-          title: Country
-          description: |
-            A country: an [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). Provide this parameter if you want the list of returned items to be relevant to a particular country. If omitted, the returned items will be relevant to all countries.
-          example: SE
-          type: string
       - $ref: '#/components/parameters/QueryLimit'
       - $ref: '#/components/parameters/QueryOffset'
       responses:
@@ -3742,6 +3686,7 @@ components:
             - categories
             properties:
               categories:
+                type: object
                 allOf:
                 - $ref: '#/components/schemas/PagingObject'
                 - type: object
@@ -5259,6 +5204,9 @@ components:
       properties:
         message:
           type: string
+          description: |
+            The localized message of a playlist.
+          example: Popular Playlists
         playlists:
           $ref: '#/components/schemas/PagingPlaylistObject'
     PagingArtistDiscographyAlbumObject:

--- a/official-spotify-open-api.yml
+++ b/official-spotify-open-api.yml
@@ -1886,33 +1886,14 @@ paths:
       description: |
         Get a list of Spotify featured playlists (shown, for example, on a Spotify player's 'Browse' tab).
       parameters:
-        - name: country
-          required: false
-          in: query
-          schema:
-            title: Country
-            description: |
-              A country: an [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). Provide this parameter if you want the list of returned items to be relevant to a particular country. If omitted, the returned items will be relevant to all countries.
-            example: SE
-            type: string
         - name: locale
           required: false
           in: query
           schema:
             title: Locale
             description: |
-              The desired language, consisting of a lowercase [ISO 639-1 language code](http://en.wikipedia.org/wiki/ISO_639-1) and an uppercase [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2), joined by an underscore. For example: `es_MX`, meaning "Spanish (Mexico)". Provide this parameter if you want the results returned in a particular language (where available). <br/>
-              _**Note**: if `locale` is not supplied, or if the specified language is not available, all strings will be returned in the Spotify default language (American English). The `locale` parameter, combined with the `country` parameter, may give odd results if not carefully matched. For example `country=SE&locale=de_DE` will return a list of categories relevant to Sweden but as German language strings._
+              The desired language, consisting of an [ISO 639-1](http://en.wikipedia.org/wiki/ISO_639-1) language code and an [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2), joined by an underscore. For example: `es_MX`, meaning &quot;Spanish (Mexico)&quot;. Provide this parameter if you want the category strings returned in a particular language.<br/> _**Note**: if `locale` is not supplied, or if the specified language is not available, the category strings returned will be in the Spotify default language (American English)._
             example: sv_SE
-            type: string
-        - name: timestamp
-          required: false
-          in: query
-          schema:
-            title: Timestamp
-            description: |
-              A timestamp in [ISO 8601 format](http://en.wikipedia.org/wiki/ISO_8601): `yyyy-MM-ddTHH:mm:ss`. Use this parameter to specify the user's local time to get results tailored for that specific date and time in the day. If not provided, the response defaults to the current UTC time. Example: "2014-10-23T09:00:00" for a user whose local time is 9AM. If there were no featured playlists (or there is no data) at the specified time, the response will revert to the current UTC time.
-            example: '2014-10-23T09:00:00'
             type: string
         - $ref: '#/components/parameters/QueryLimit'
         - $ref: '#/components/parameters/QueryOffset'
@@ -1937,23 +1918,13 @@ paths:
       description: |
         Get a list of categories used to tag items in Spotify (on, for example, the Spotify player’s “Browse” tab).
       parameters:
-        - name: country
-          required: false
-          in: query
-          schema:
-            title: Country
-            description: |
-              A country: an [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). Provide this parameter if you want to narrow the list of returned categories to those relevant to a particular country. If omitted, the returned items will be globally relevant.
-            example: SE
-            type: string
         - name: locale
           required: false
           in: query
           schema:
             title: Locale
             description: |
-              The desired language, consisting of an [ISO 639-1](http://en.wikipedia.org/wiki/ISO_639-1) language code and an [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2), joined by an underscore. For example: `es_MX`, meaning "Spanish (Mexico)". Provide this parameter if you want the category metadata returned in a particular language. <br/>
-              _**Note**: if `locale` is not supplied, or if the specified language is not available, all strings will be returned in the Spotify default language (American English). The `locale` parameter, combined with the `country` parameter, may give odd results if not carefully matched. For example `country=SE&locale=de_DE` will return a list of categories relevant to Sweden but as German language strings._
+              The desired language, consisting of an [ISO 639-1](http://en.wikipedia.org/wiki/ISO_639-1) language code and an [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2), joined by an underscore. For example: `es_MX`, meaning &quot;Spanish (Mexico)&quot;. Provide this parameter if you want the category strings returned in a particular language.<br/> _**Note**: if `locale` is not supplied, or if the specified language is not available, the category strings returned will be in the Spotify default language (American English)._
             example: sv_SE
             type: string
         - $ref: '#/components/parameters/QueryLimit'
@@ -1987,15 +1958,6 @@ paths:
             description: |
               The [Spotify category ID](/documentation/web-api/concepts/spotify-uris-ids) for the category.
             example: dinner
-            type: string
-        - name: country
-          required: false
-          in: query
-          schema:
-            title: Country
-            description: |
-              A country: an [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). Provide this parameter to ensure that the category exists for a particular country.
-            example: SE
             type: string
         - name: locale
           required: false
@@ -2036,15 +1998,6 @@ paths:
             description: |
               The [Spotify category ID](/documentation/web-api/concepts/spotify-uris-ids) for the category.
             example: dinner
-            type: string
-        - name: country
-          required: false
-          in: query
-          schema:
-            title: Country
-            description: |
-              A country: an [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). Provide this parameter to ensure that the category exists for a particular country.
-            example: SE
             type: string
         - $ref: '#/components/parameters/QueryLimit'
         - $ref: '#/components/parameters/QueryOffset'
@@ -2128,15 +2081,6 @@ paths:
       description: |
         Get a list of new album releases featured in Spotify (shown, for example, on a Spotify player’s “Browse” tab).
       parameters:
-        - name: country
-          required: false
-          in: query
-          schema:
-            title: Country
-            description: |
-              A country: an [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). Provide this parameter if you want the list of returned items to be relevant to a particular country. If omitted, the returned items will be relevant to all countries.
-            example: SE
-            type: string
         - $ref: '#/components/parameters/QueryLimit'
         - $ref: '#/components/parameters/QueryOffset'
       responses:
@@ -3823,7 +3767,15 @@ components:
               - categories
             properties:
               categories:
-                $ref: '#/components/schemas/PagingObject'
+                type: object
+                allOf:
+                  - $ref: '#/components/schemas/PagingObject'
+                  - type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/CategoryObject'
 
     CursorPagedArtists:
       description: A paged set of artists
@@ -5300,6 +5252,9 @@ components:
       properties:
         message:
           type: string
+          description: |
+            The localized message of a playlist.
+          example: Popular Playlists
         playlists:
           $ref: '#/components/schemas/PagingPlaylistObject'
 


### PR DESCRIPTION
Automated update of Spotify's OpenAPI definition

Generated by [this workflow run](https://github.com/sonallux/spotify-web-api/actions/runs/7860896076).