### PR TITLE
Update of Spotify's OpenAPI definition

### DIFF
--- a/fixed-spotify-open-api.yml
+++ b/fixed-spotify-open-api.yml
@@ -144,7 +144,7 @@ paths:
         schema:
           title: Spotify Artist IDs
           description: |
-            A comma-separated list of the [Spotify IDs](/documentation/web-api/concepts/spotify-uris-ids) for the artists. Maximum: 100 IDs.
+            A comma-separated list of the [Spotify IDs](/documentation/web-api/concepts/spotify-uris-ids) for the artists. Maximum: 50 IDs.
           example: "2CIMQHirSU0MQqyYHq0eOx,57dN52uHvrHOxijzpIgu3E,1vCWHaC5f2uS3yhpwWbIA6"
           type: string
       responses:
@@ -638,7 +638,7 @@ paths:
         schema:
           title: Spotify Track IDs
           description: |
-            A comma-separated list of the [Spotify IDs](/documentation/web-api/concepts/spotify-uris-ids). For example: `ids=4iV5W9uYEdYUVa79Axb7Rh,1301WleyT98MSxVHPZCA6M`. Maximum: 100 IDs.
+            A comma-separated list of the [Spotify IDs](/documentation/web-api/concepts/spotify-uris-ids). For example: `ids=4iV5W9uYEdYUVa79Axb7Rh,1301WleyT98MSxVHPZCA6M`. Maximum: 50 IDs.
           example: "7ouMYWpwJ422jRcDASZB7P,4VqPOruhp5EdPBeR92t6lQ,2takcwOaAZWiXQijPHIx7B"
           type: string
       responses:

--- a/official-spotify-open-api.yml
+++ b/official-spotify-open-api.yml
@@ -154,7 +154,7 @@ paths:
           schema:
             title: Spotify Artist IDs
             description: |
-              A comma-separated list of the [Spotify IDs](/documentation/web-api/concepts/spotify-uris-ids) for the artists. Maximum: 100 IDs.
+              A comma-separated list of the [Spotify IDs](/documentation/web-api/concepts/spotify-uris-ids) for the artists. Maximum: 50 IDs.
             example: 2CIMQHirSU0MQqyYHq0eOx,57dN52uHvrHOxijzpIgu3E,1vCWHaC5f2uS3yhpwWbIA6
             type: string
       responses:
@@ -679,7 +679,7 @@ paths:
           schema:
             title: Spotify Track IDs
             description: |
-              A comma-separated list of the [Spotify IDs](/documentation/web-api/concepts/spotify-uris-ids). For example: `ids=4iV5W9uYEdYUVa79Axb7Rh,1301WleyT98MSxVHPZCA6M`. Maximum: 100 IDs.
+              A comma-separated list of the [Spotify IDs](/documentation/web-api/concepts/spotify-uris-ids). For example: `ids=4iV5W9uYEdYUVa79Axb7Rh,1301WleyT98MSxVHPZCA6M`. Maximum: 50 IDs.
             example: 7ouMYWpwJ422jRcDASZB7P,4VqPOruhp5EdPBeR92t6lQ,2takcwOaAZWiXQijPHIx7B
             type: string
       responses:


### PR DESCRIPTION
Automated update of Spotify's OpenAPI definition

Generated by [this workflow run](https://github.com/sonallux/spotify-web-api/actions/runs/9867281746).