### PR TITLE
Update of Spotify's OpenAPI definition

### DIFF
--- a/fixed-spotify-open-api.yml
+++ b/fixed-spotify-open-api.yml
@@ -1311,6 +1311,26 @@ paths:
                     A JSON array of the [Spotify IDs](/documentation/web-api/concepts/spotify-uris-ids). For example: `["4iV5W9uYEdYUVa79Axb7Rh", "1301WleyT98MSxVHPZCA6M"]`<br/>A maximum of 50 items can be specified in one request. _**Note**: if the `ids` parameter is present in the query string, any IDs listed here in the body will be ignored._
                   items:
                     type: string
+                timestamped_ids:
+                  type: array
+                  description: |
+                    A JSON array of objects containing track IDs with their corresponding timestamps. Each object must include a track ID and an `added_at` timestamp. This allows you to specify when tracks were added to maintain a specific chronological order in the user's library.<br/>A maximum of 50 items can be specified in one request. _**Note**: if the `timestamped_ids` is present in the body, any IDs listed in the query parameters or the `ids` field in the body will be ignored._
+                  items:
+                    type: object
+                    required:
+                    - id
+                    - added_at
+                    properties:
+                      id:
+                        type: string
+                        description: |
+                          The [Spotify ID](/documentation/web-api/concepts/spotify-uris-ids) for the track.
+                      added_at:
+                        type: string
+                        format: date-time
+                        x-spotify-docs-type: Timestamp
+                        description: |
+                          The timestamp when the track was added to the library. Use ISO 8601 format with UTC timezone (e.g., `2023-01-15T14:30:00Z`). You can specify past timestamps to insert tracks at specific positions in the library's chronological order. The API uses minute-level granularity for ordering, though the timestamp supports millisecond precision.
       responses:
         "200":
           description: Track saved

--- a/official-spotify-open-api.yml
+++ b/official-spotify-open-api.yml
@@ -1348,6 +1348,26 @@ paths:
                     A JSON array of the [Spotify IDs](/documentation/web-api/concepts/spotify-uris-ids). For example: `["4iV5W9uYEdYUVa79Axb7Rh", "1301WleyT98MSxVHPZCA6M"]`<br/>A maximum of 50 items can be specified in one request. _**Note**: if the `ids` parameter is present in the query string, any IDs listed here in the body will be ignored._
                   items:
                     type: string
+                timestamped_ids:
+                  type: array
+                  description: |
+                    A JSON array of objects containing track IDs with their corresponding timestamps. Each object must include a track ID and an `added_at` timestamp. This allows you to specify when tracks were added to maintain a specific chronological order in the user's library.<br/>A maximum of 50 items can be specified in one request. _**Note**: if the `timestamped_ids` is present in the body, any IDs listed in the query parameters or the `ids` field in the body will be ignored._
+                  items:
+                    type: object
+                    required:
+                      - id
+                      - added_at
+                    properties:
+                      id:
+                        type: string
+                        description: |
+                          The [Spotify ID](/documentation/web-api/concepts/spotify-uris-ids) for the track.
+                      added_at:
+                        type: string
+                        format: date-time
+                        x-spotify-docs-type: Timestamp
+                        description: |
+                          The timestamp when the track was added to the library. Use ISO 8601 format with UTC timezone (e.g., `2023-01-15T14:30:00Z`). You can specify past timestamps to insert tracks at specific positions in the library's chronological order. The API uses minute-level granularity for ordering, though the timestamp supports millisecond precision.
       responses:
         '200':
           description: Track saved


### PR DESCRIPTION
Automated update of Spotify's OpenAPI definition

Generated by [this workflow run](https://github.com/sonallux/spotify-web-api/actions/runs/15840392304).