### PR TITLE
Update of Spotify's OpenAPI definition

### DIFF
--- a/fixed-spotify-open-api.yml
+++ b/fixed-spotify-open-api.yml
@@ -738,11 +738,11 @@ paths:
           title: Limit
           description: |
             The maximum number of results to return in each item type.
-          default: 20
+          default: 5
           example: 10
           type: integer
           minimum: 1
-          maximum: 50
+          maximum: 10
       - name: offset
         required: false
         in: query
@@ -6923,6 +6923,7 @@ components:
         - album_group
         properties:
           album_group:
+            deprecated: true
             type: string
             enum:
             - album

--- a/official-spotify-open-api.yml
+++ b/official-spotify-open-api.yml
@@ -782,11 +782,11 @@ paths:
             title: Limit
             description: |
               The maximum number of results to return in each item type.
-            default: 20
+            default: 5
             example: 10
             type: integer
             minimum: 0
-            maximum: 50
+            maximum: 10
         - name: offset
           required: false
           in: query
@@ -6990,6 +6990,7 @@ components:
             - album_group
           properties:
             album_group:
+              deprecated: true
               type: string
               enum: [album, single, compilation, appears_on]
               example: compilation


### PR DESCRIPTION
Automated update of Spotify's OpenAPI definition

Generated by [this workflow run](https://github.com/sonallux/spotify-web-api/actions/runs/22010987058).