### PR TITLE
Update of Spotify's OpenAPI definition

### DIFF
--- a/fixed-spotify-open-api.yml
+++ b/fixed-spotify-open-api.yml
@@ -4955,6 +4955,11 @@ components:
       type: object
       x-spotify-docs-type: PrivateUserObject
       properties:
+        account_id:
+          type: string
+          description: |
+            A public, immutable, pseudoanonymous identifier for the user's account. Use this field for account linking rather than the `id` field, as it is stable and will not change over the lifetime of the account.
+          example: aB3dE5fG7h
         country:
           deprecated: true
           type: string
@@ -4991,7 +4996,7 @@ components:
         id:
           type: string
           description: |
-            The [Spotify user ID](/documentation/web-api/concepts/spotify-uris-ids) for the user.
+            The [Spotify user ID](/documentation/web-api/concepts/spotify-uris-ids) for the user. Do not use this field for account linking — use `account_id` instead, which is immutable.
         images:
           type: array
           items:

--- a/official-spotify-open-api.yml
+++ b/official-spotify-open-api.yml
@@ -5067,6 +5067,11 @@ components:
       type: object
       x-spotify-docs-type: PrivateUserObject
       properties:
+        account_id:
+          type: string
+          description: |
+            A public, immutable, pseudoanonymous identifier for the user's account. Use this field for account linking rather than the `id` field, as it is stable and will not change over the lifetime of the account.
+          example: 'aB3dE5fG7h'
         country:
           deprecated: true
           type: string
@@ -5103,7 +5108,7 @@ components:
         id:
           type: string
           description: |
-            The [Spotify user ID](/documentation/web-api/concepts/spotify-uris-ids) for the user.
+            The [Spotify user ID](/documentation/web-api/concepts/spotify-uris-ids) for the user. Do not use this field for account linking — use `account_id` instead, which is immutable.
         images:
           type: array
           items:


### PR DESCRIPTION
Automated update of Spotify's OpenAPI definition

Generated by [this workflow run](https://github.com/sonallux/spotify-web-api/actions/runs/26676197346).